### PR TITLE
Don't fail on click on empty area

### DIFF
--- a/lib/double-click-tree-view.js
+++ b/lib/double-click-tree-view.js
@@ -10,6 +10,10 @@ export default {
             console.log(this.treeView.originalEntryClicked.toString());
             this.treeView.entryClicked = function(e) {
                 let entry = e.target.closest('.entry');
+                if (!entry) {
+                    return;
+                }
+
                 let isRecursive = e.altKey || false;
                 if (e.detail == 1 && entry.classList.contains('directory') && e.offsetX <= 10) {
                     entry.toggleExpansion(isRecursive);


### PR DESCRIPTION
When I click on empty space of tree view panel, I get an error:
```
C:\Users\esprit\.atom\packages\dbclick-tree-view\lib\double-click-tree-view.js:15
TypeError: Cannot read property 'classList' of null
    at TreeView._this.treeView.entryClicked (file:///C:/Users/esprit/.atom/packages/dbclick-tree-view/lib/double-click-tree-view.js:15:43)
    at HTMLDivElement.<anonymous> (C:\Users\esprit\AppData\Local\atom\app-1.16.0\resources\app.asar\node_modules\tree-view\lib\tree-view.js:154:26)
```
This happens because `entry` variable is null when the click event is triggered. In the original `entryClicked` function was a check if entry is null:
```js
function(e) {
    var entry, isRecursive;
    if (entry = e.target.closest('.entry')) {
        // process click event
    }
}
```

To fix the issue I moved this one back.