### PR TITLE
Don't process single clicks for files

### DIFF
--- a/lib/double-click-tree-view.js
+++ b/lib/double-click-tree-view.js
@@ -11,14 +11,14 @@ export default {
             this.treeView.entryClicked = function(e) {
                 let entry = e.target.closest('.entry');
                 let isRecursive = e.altKey || false;
-                if (e.detail == 1 && entry.classList.contains('directory') && e.offsetX <= 10) {
-                    entry.toggleExpansion(isRecursive);
-                } else {
+                if (e.detail == 1) {
                     this.selectEntry(entry);
+                    if (entry.classList.contains('directory') && e.offsetX <= 10) {
+                        entry.toggleExpansion(isRecursive);
+                    }
+                } else if (e.detail == 2) {
                     if (entry.classList.contains('directory')) {
-                        if (e.detail > 1) {
-                            entry.toggleExpansion(isRecursive);
-                        }
+                        entry.toggleExpansion(isRecursive);
                     } else if (entry.classList.contains('file')) {
                         this.fileViewEntryClicked(e);
                     }


### PR DESCRIPTION
The package still processes single clicks on files for me. I unable to select a file by single-click. Instead of this a file is opened in a new tab, like vanilla Atom does.

Here is the fix of this behavior.