### PR TITLE
Enhancement: in case Allow Pending Pane Items is set to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # double-click-tree-view package for atom editor
 
-By default, the atom tree-view for browsing files/directories will open a file or collapse / expand 
-a directory listing just by single-clicking on the entry. 
+By default, the atom tree-view for browsing files/directories will open a file or collapse / expand
+a directory listing just by single-clicking on the entry.
 
-This package forces the user to double click on a file to open it, or on a directory to expand/collapse it. This effectively turns a single-click into just selecting the item clicked on, which is the default behavior in most editors. 
+This package allows the user to choose single or double click on a file to open it, or on a directory to expand/collapse it. This effectively turns a single-click into just selecting the item clicked on, which is the default behavior in most editors.
+
+Tips: if `Allow Pending Pane Items` in `Settings/Core` is set to false and `Enable on file` of this package setting is set to false, single click on file will open the file.
 
 To install:
 
@@ -11,7 +13,7 @@ To install:
 
 
 
-Big thanks to mattsfrey and h2so5 for writing the original projects that this has been forked from. 
+Big thanks to mattsfrey and h2so5 for writing the original projects that this has been forked from.
 
 https://github.com/h2so5/atom-chary-tree-view
 

--- a/lib/double-click-tree-view.js
+++ b/lib/double-click-tree-view.js
@@ -43,12 +43,17 @@ export default {
                 let isRecursive = e.altKey || false;
                 if (e.detail == 1) {
                     if (!config.enableOnFile && ctx.isFile(entry)) {
-                        return this.fileViewEntryClicked(e);
+                        if (ctx.isPendingPaneAllowed()) {
+                            return this.fileViewEntryClicked(e);
+                        }
+                        this.selectEntry(entry);
+                        this.openSelectedEntry();
+                        return;
                     }
                     this.selectEntry(entry);
                     if (
                         ctx.isDirectory(entry) &&
-                        (e.offsetX <= 10 || !config.enableOnFolder)
+                        (ctx.isClickOnArrow(e) || !config.enableOnFolder)
                     ) {
                         entry.toggleExpansion(isRecursive);
                     }
@@ -62,11 +67,17 @@ export default {
             }
         });
     },
+    isPendingPaneAllowed() {
+        return atom.config.get('core.allowPendingPaneItems');
+    },
     isDirectory(entry) {
         return entry.classList.contains('directory');
     },
     isFile(entry) {
         return entry.classList.contains('file');
+    },
+    isClickOnArrow(e) {
+        return e.offsetX <= 10;
     },
     deactivate() {
         this.treeView.entryClicked = this.treeView.originalEntryClicked;


### PR DESCRIPTION
Enhancement: if `Allow Pending Pane Items` in `Settings/Core` is set to false and `Enable on file` of this package setting is set to false, single click on file will open the file.